### PR TITLE
Error in checkPartKey() if VOI is installed using swarm.

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -174,7 +174,7 @@ def checkPartKey():
   mylastround = 0
   
   if (isSwarmEnabled):
-    goal = runCommand([swarmGoalCommand,'node','lastround'])
+    goal = runCommand([swarmGoalCommand,'node','lastround']).strip().split("\n")[-1]
   else:
     goal = runCommand(['goal','node','lastround'])
   thisround = int(goal)


### PR DESCRIPTION
If VOI node is installed using swarm, `goal` adds following two lines to the beginning of the output and this brakes `checkPartKey()` function where we try to get `lastround` information.

```bash
Executing Voi 'goal' wrapper from /root/voi/bin/goal
---
```

Fix: Output is stripped first, then splitted by "\\n". Last element of the splitted string is the lastround information that we are looking for.